### PR TITLE
add build string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set cffi_version = "1.14.3" %}
 {% set python_maj_min = ".".join(python_version.split(".")[:2]) %}
 # Keep increasing this until we get a new python_version. Do not reset
-{% set build_num = "4" %}
+{% set build_num = "5" %}
 {% set pypy_abi = "".join(version.split(".")[:2]) %}
 
 package:
@@ -51,6 +51,7 @@ outputs:
     version: {{ version }}
     build:
       number: {{ build_num }}
+      string: pypy {{ python_maj_min }}
       noarch: generic
     requirements:
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
     version: {{ version }}
     build:
       number: {{ build_num }}
-      string: pypy {{ python_maj_min }}
+      string: {{ build_num }}_pypy{{ python_maj_min.replace(".", "") }}
       noarch: generic
     requirements:
       run:
@@ -64,7 +64,7 @@ outputs:
     version: {{ cffi_version }}
     build:
       number: {{ build_num }}
-      string: {{ build_num }}_pypy
+      string: {{ build_num }}_pypy{{ python_maj_min.replace(".", "") }}
       noarch: generic
     requirements:
       run:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The build string was missing, so the metapackage name is pypy not pypy3.6 or pypy3.7. Is that the correct way to think about this?
